### PR TITLE
feat(map): extract MapLibre lifecycle into useMapLibreMap hook

### DIFF
--- a/src/features/map/MapView.tsx
+++ b/src/features/map/MapView.tsx
@@ -1,40 +1,72 @@
 import { useEffect, useRef, useState } from "react";
 import maplibregl from "maplibre-gl";
 import { parseGeoJson } from "@/utils/json_parser";
+import { useMapLibreMap } from "./hooks/useMapLibreMap";
 
 const MAP_STYLE = "https://tiles.openfreemap.org/styles/bright";
 const GEOJSON_PATH = "/discounts.json";
+const MAP_CENTER: [number, number] = [19.94, 50.06];
+const MAP_ZOOM = 12;
+
+type DiscountPoint = {
+  id: number;
+  name: string;
+  address: string;
+  coordinates: [number, number];
+};
 
 export default function MapView() {
-  const mapContainerRef = useRef<HTMLDivElement>(null);
-  const mapRef = useRef<maplibregl.Map | null>(null);
-  const [discountsArray, setDiscount] = useState([]);
+  const { mapContainerRef, mapRef } = useMapLibreMap({
+    style: MAP_STYLE,
+    center: MAP_CENTER,
+    zoom: MAP_ZOOM,
+  });
+  const markersRef = useRef<maplibregl.Marker[]>([]);
+  const [discountsArray, setDiscount] = useState<DiscountPoint[]>([]);
 
   useEffect(() => {
     fetch(GEOJSON_PATH)
-      .then((response) => response.json())
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to fetch discounts data: ${response.status}`);
+        }
+
+        return response.json();
+      })
       .then((geoJson) => {
-        const discounts = parseGeoJson(geoJson);
+        const discounts = parseGeoJson(geoJson) as DiscountPoint[];
         setDiscount(discounts);
+      })
+      .catch((error) => {
+        console.error(error);
+        setDiscount([]);
       });
   }, []);
 
   useEffect(() => {
-    if (!mapContainerRef.current || mapRef.current) return;
+    if (!mapRef.current) return;
 
-    mapRef.current = new maplibregl.Map({
-      container: mapContainerRef.current,
-      style: MAP_STYLE,
-      center: [19.94, 50.06],
-      zoom: 12,
+    markersRef.current.forEach((marker) => marker.remove());
+    markersRef.current = [];
+
+    discountsArray.forEach((discount) => {
+      const popup = new maplibregl.Popup({ offset: 25 }).setHTML(
+        `<strong>${discount.name}</strong><br />${discount.address}`,
+      );
+
+      const marker = new maplibregl.Marker({ color: "#c57b57" })
+        .setLngLat(discount.coordinates)
+        .setPopup(popup)
+        .addTo(mapRef.current!);
+
+      markersRef.current.push(marker);
     });
-    const marker = new maplibregl.Marker()
-      .setLngLat([19.94, 50.06])
-      .addTo(mapRef.current);
+  }, [discountsArray]);
 
+  useEffect(() => {
     return () => {
-      mapRef.current?.remove();
-      mapRef.current = null;
+      markersRef.current.forEach((marker) => marker.remove());
+      markersRef.current = [];
     };
   }, []);
 
@@ -44,7 +76,7 @@ export default function MapView() {
       style={{
         width: "100%",
         height: "100%",
-        backgroundColor: "#eee", // debug
+        backgroundColor: "#eee",
       }}
     />
   );

--- a/src/features/map/hooks/useMapLibreMap.ts
+++ b/src/features/map/hooks/useMapLibreMap.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react";
+import maplibregl from "maplibre-gl";
+
+type UseMapLibreMapParams = {
+  style: string;
+  center: [number, number];
+  zoom: number;
+};
+
+export const useMapLibreMap = ({
+  style,
+  center,
+  zoom,
+}: UseMapLibreMapParams) => {
+  const mapContainerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<maplibregl.Map | null>(null);
+
+  useEffect(() => {
+    if (!mapContainerRef.current || mapRef.current) return;
+
+    mapRef.current = new maplibregl.Map({
+      container: mapContainerRef.current,
+      style,
+      center,
+      zoom,
+    });
+
+    return () => {
+      mapRef.current?.remove();
+      mapRef.current = null;
+    };
+  }, [style, center, zoom]);
+
+  return { mapContainerRef, mapRef };
+};


### PR DESCRIPTION
Refactored map initialization by extracting MapLibre instance creation, storage, and cleanup lifecycle into a dedicated React hook: useMapLibreMap. This separates map integration logic from MapView presentation and improves reusability.
