### PR TITLE
feat(map): extract MapLibre lifecycle into hook and stabilize marker …

### DIFF
--- a/src/features/map/MapView.tsx
+++ b/src/features/map/MapView.tsx
@@ -1,42 +1,45 @@
 import { useEffect, useRef, useState } from "react";
-import maplibregl from "maplibre-gl";
+import maplibregl, { type LngLatLike } from "maplibre-gl";
 import { parseGeoJson } from "../../utils/json_parser";
+import { type ActiveDiscount } from "./SideBar";
+import { useMapLibreMap } from "./hooks/useMapLibreMap";
+
+type DiscountDetails = NonNullable<ActiveDiscount>;
+type DiscountMapItem = DiscountDetails & {
+  coordinates: [number, number];
+};
 
 interface MapViewProps {
-  onMarkerClick: (data: any) => void;
+  onMarkerClick: (data: DiscountDetails) => void;
 }
 
+const MAP_STYLE = "https://tiles.openfreemap.org/styles/bright";
+const MAP_CENTER: [number, number] = [19.94, 50.06];
+const MAP_ZOOM = 12;
+
 export default function MapView({ onMarkerClick }: MapViewProps) {
-  const mapContainerRef = useRef<HTMLDivElement>(null);
-  const mapRef = useRef<maplibregl.Map | null>(null);
-  const [discountsArray, setDiscountsArray] = useState<any[]>([]);
+  const { mapContainerRef, mapRef } = useMapLibreMap({
+    style: MAP_STYLE,
+    center: MAP_CENTER,
+    zoom: MAP_ZOOM,
+  });
+  const [discountsArray, setDiscountsArray] = useState<DiscountMapItem[]>([]);
   const extraMarkersRef = useRef<maplibregl.Marker[]>([]);
+  const onMarkerClickRef = useRef(onMarkerClick);
+
+  useEffect(() => {
+    onMarkerClickRef.current = onMarkerClick;
+  }, [onMarkerClick]);
 
   useEffect(() => {
     const fetchData = async () => {
       const response = await fetch("/src/assets/discounts.json");
       const data = await response.json();
-      const parsedData = parseGeoJson(data);
+      const parsedData = parseGeoJson(data) as DiscountMapItem[];
       setDiscountsArray(parsedData);
     };
 
     fetchData();
-  }, []);
-
-  useEffect(() => {
-    if (!mapContainerRef.current || mapRef.current) return;
-
-    mapRef.current = new maplibregl.Map({
-      container: mapContainerRef.current,
-      style: "https://tiles.openfreemap.org/styles/bright",
-      center: [19.94, 50.06],
-      zoom: 12,
-    });
-
-    return () => {
-      mapRef.current?.remove();
-      mapRef.current = null;
-    };
   }, []);
 
   useEffect(() => {
@@ -50,11 +53,11 @@ export default function MapView({ onMarkerClick }: MapViewProps) {
     extraMarkersRef.current.forEach((marker) => marker.remove());
     extraMarkersRef.current = discountsArray.map((discount) => {
       const marker = new maplibregl.Marker()
-        .setLngLat(discount.coordinates)
+        .setLngLat(discount.coordinates as LngLatLike)
         .addTo(mapRef.current!);
 
       const markerElement = marker.getElement();
-      const handleClick = () => onMarkerClick(discount);
+      const handleClick = () => onMarkerClickRef.current(discount);
       markerElement.addEventListener("click", handleClick);
       markerListeners.push({ element: markerElement, handler: handleClick });
 
@@ -68,7 +71,7 @@ export default function MapView({ onMarkerClick }: MapViewProps) {
       extraMarkersRef.current.forEach((marker) => marker.remove());
       extraMarkersRef.current = [];
     };
-  }, [discountsArray, onMarkerClick]);
+  }, [discountsArray, mapRef]);
 
   return <div ref={mapContainerRef} className="w-full h-full bg-gray-200" />;
 }

--- a/src/features/map/SideBar.tsx
+++ b/src/features/map/SideBar.tsx
@@ -1,13 +1,13 @@
 /**
  *  Tutaj wygląd i animacja SideBara dane są przekazywane przez prop children
  */
-type DiscountItem = {
+export type DiscountItem = {
   label: string;
   type: string;
   conditions: string | null;
 };
 
-type ActiveDiscount = {
+export type ActiveDiscount = {
   id: number;
   name: string;
   address: string;

--- a/src/features/map/hooks/useMapLibreMap.ts
+++ b/src/features/map/hooks/useMapLibreMap.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react";
+import maplibregl from "maplibre-gl";
+
+type UseMapLibreMapParams = {
+  style: string;
+  center: [number, number];
+  zoom: number;
+};
+
+export const useMapLibreMap = ({
+  style,
+  center,
+  zoom,
+}: UseMapLibreMapParams) => {
+  const mapContainerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<maplibregl.Map | null>(null);
+
+  useEffect(() => {
+    if (!mapContainerRef.current || mapRef.current) return;
+
+    mapRef.current = new maplibregl.Map({
+      container: mapContainerRef.current,
+      style,
+      center,
+      zoom,
+    });
+
+    return () => {
+      mapRef.current?.remove();
+      mapRef.current = null;
+    };
+  }, [style, center, zoom]);
+
+  return { mapContainerRef, mapRef };
+};

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -1,9 +1,12 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import MapView from "../features/map/MapView";
-import SideBar from "../features/map/SideBar";
+import SideBar, { type ActiveDiscount } from "../features/map/SideBar";
 
 export default function MapPage() {
-  const [activeDiscount, setActiveDiscount] = useState<any>(null);
+  const [activeDiscount, setActiveDiscount] = useState<ActiveDiscount>(null);
+  const handleMarkerClick = useCallback((data: NonNullable<ActiveDiscount>) => {
+    setActiveDiscount(data);
+  }, []);
 
   return (
     <div className="relative h-screen w-screen overflow-hidden">
@@ -13,7 +16,7 @@ export default function MapPage() {
         activeDiscount={activeDiscount}
       />
 
-      <MapView onMarkerClick={(data) => setActiveDiscount(data)} />
+      <MapView onMarkerClick={handleMarkerClick} />
     </div>
   );
 }


### PR DESCRIPTION
Extracted MapLibre map lifecycle (create/store/cleanup) into a dedicated useMapLibreMap hook and updated MapView to use it. Also stabilized marker click handling so sidebar state updates do not recreate marker listeners/instances.