### PR TITLE
chowanie panelu bocznego dla mobilek

### DIFF
--- a/src/features/map/DiscountMarkers.tsx
+++ b/src/features/map/DiscountMarkers.tsx
@@ -11,7 +11,6 @@ interface DiscountMarkersProps {
 }
 
 const ICON_MAP: Record<string, string> = {
-  //Zrobione troche losowo, można pomyśleć żeby jakoś lepiej te kategorie dopasować
   Gastronomia: 'url("/icons/znacznik_gastronomia.svg")',
   Inne: 'url("/icons/znacznik_inne.svg")',
   Rozrywka: 'url("/icons/znacznik_kultura_sztuka.svg")',
@@ -32,7 +31,9 @@ export default function DiscountMarkers({
     const markerInstances: maplibregl.Marker[] = [];
     const markerListeners: Array<{
       element: HTMLElement;
-      handler: () => void;
+      // --- ZMIANA: Aktualizacja typu handlera, by przyjmował obiekt zdarzenia myszy ---
+      handler: (e: MouseEvent) => void;
+      // --- KONIEC ZMIANY ---
     }> = [];
 
     discounts.forEach((discount) => {
@@ -50,7 +51,14 @@ export default function DiscountMarkers({
         .addTo(map);
 
       const markerElement = marker.getElement();
-      const handleClick = () => onMarkerClick(discount);
+      
+      // --- ZMIANA: Przechwycenie obiektu 'e' i zatrzymanie bąbelkowania przed uderzeniem w mapę ---
+      const handleClick = (e: MouseEvent) => {
+        e.stopPropagation();
+        onMarkerClick(discount);
+      };
+      // --- KONIEC ZMIANY ---
+      
       markerElement.addEventListener("click", handleClick);
       markerListeners.push({ element: markerElement, handler: handleClick });
 

--- a/src/features/map/MapView.tsx
+++ b/src/features/map/MapView.tsx
@@ -12,13 +12,14 @@ type DiscountMapItem = DiscountDetails & {
 
 interface MapViewProps {
   onMarkerClick: (data: DiscountDetails) => void;
+  onMapClick: () => void;
 }
 
 const MAP_STYLE = "https://tiles.openfreemap.org/styles/bright";
 const MAP_CENTER: [number, number] = [19.94, 50.06];
 const MAP_ZOOM = 12;
 
-export default function MapView({ onMarkerClick }: MapViewProps) {
+export default function MapView({ onMarkerClick, onMapClick }: MapViewProps) {
   const { mapContainerRef, mapRef } = useMapLibreMap({
     style: MAP_STYLE,
     center: MAP_CENTER,
@@ -27,10 +28,36 @@ export default function MapView({ onMarkerClick }: MapViewProps) {
   const [discountsArray, setDiscountsArray] = useState<DiscountMapItem[]>([]);
   const extraMarkersRef = useRef<maplibregl.Marker[]>([]);
   const onMarkerClickRef = useRef(onMarkerClick);
+  
+  const onMapClickRef = useRef(onMapClick);
+  useEffect(() => {
+    onMapClickRef.current = onMapClick;
+  }, [onMapClick]);
 
   useEffect(() => {
     onMarkerClickRef.current = onMarkerClick;
   }, [onMarkerClick]);
+
+  // --- ZMIANA: Zmiana tablicy zależności z [mapRef] na [mapRef.current] ---
+  // Reagujemy na moment, w którym referencja wypełni się załadowaną mapą, 
+  // a nie na sam stały obiekt referencji.
+  useEffect(() => {
+    if (!mapRef.current) return;
+    const map = mapRef.current;
+
+    const handleMapClick = () => {
+      if (onMapClickRef.current) {
+        onMapClickRef.current();
+      }
+    };
+
+    map.on("click", handleMapClick);
+
+    return () => {
+      map.off("click", handleMapClick);
+    };
+  }, [mapRef.current]);
+  // --- KONIEC ZMIANY ---
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -16,7 +16,16 @@ export default function MapPage() {
         activeDiscount={activeDiscount}
       />
 
-      <MapView onMarkerClick={handleMarkerClick} />
+      {/* --- ZMIANA: Zamykanie panelu tylko na urządzeniach mobilnych (poniżej 768px) --- */}
+      <MapView 
+        onMarkerClick={handleMarkerClick} 
+        onMapClick={() => {
+          if (window.innerWidth < 768) {
+            setActiveDiscount(null);
+          }
+        }}
+      />
+      {/* --- KONIEC ZMIANY --- */}
     </div>
   );
 }


### PR DESCRIPTION

Wdrożenie responsywnego mechanizm zamykania panelu bocznego

Dla urzadzeń w szerokosci < 768 uzyskujemy funkcjonalnosc "odlikiwania" panelu bocznego aby przegladac mape.
Kiedy klikniemy w jakiś inny marker uzyskujemy informacje o markerze na panelu a nie wyjscie z panelu.